### PR TITLE
Enforces UTF-8 encoding

### DIFF
--- a/boards.rb
+++ b/boards.rb
@@ -21,7 +21,7 @@ end
 
 def fetch_trello_boards(url)
   resp = RestClient.get(url)
-  boards = JSON.parse(resp)
+  boards = JSON.parse(resp.body.force_encoding('UTF-8'))
 rescue RestClient::Unauthorized
   auth_msg = "Unauthorized error. Unable to fetch from API. Exiting"
   log auth_msg

--- a/feedback.rb
+++ b/feedback.rb
@@ -4,7 +4,7 @@ require 'rexml/document'
 def main
   lines = open('boards.json', 'r') { |f| f.read }
   text = ARGV[0]
-  boards = JSON.parse(lines)
+  boards = JSON.parse(lines.force_encoding('UTF-8'))
   log "testing text: [#{text}] against [#{boards.count}] boards"
   if text && text != ''
     log "scoring boards as text is present"


### PR DESCRIPTION
I had an encoding issue with the payload so the board caching failed silently.
Using `force_encoding` solved it.
